### PR TITLE
[WIP] add regression test and fix ranges rendering issue in Desktop

### DIFF
--- a/0002-multiple-ranges-in-one-line/README.md
+++ b/0002-multiple-ranges-in-one-line/README.md
@@ -8,5 +8,11 @@ Here's a screenshot of the issue:
 
 The steps to reproduce this are as follows:
 
- - first commit - adding the baseline file contents
- - second commit - apply changes to illustrate the issue
+ - first commit - [2c03970](https://github.com/desktop/diff-tests/commit/2c0397080276eafd205672560998707a1ce72a75) - adding the baseline file contents
+ - second commit - [2c22303](https://github.com/desktop/diff-tests/commit/2c2230362afd3e73ef44569e17251edd74c8f2bc) - apply changes to demonstrate the issue
+
+Unified diff on website of the second commit:
+
+<img width="1011" rc="https://user-images.githubusercontent.com/359239/38650668-7b12588e-3e40-11e8-8325-62ab27a16dd8.png">
+
+Note the first line of the diff highlights the ranges of characters that have been updated.

--- a/0002-multiple-ranges-in-one-line/README.md
+++ b/0002-multiple-ranges-in-one-line/README.md
@@ -1,0 +1,12 @@
+## Multiple ranges in one line
+
+This folder is a reproduction of an issue reported in Desktop: https://github.com/desktop/desktop/issues/2700
+
+Here's a screenshot of the issue:
+
+![](https://user-images.githubusercontent.com/359239/29397119-850b247a-835f-11e7-94f5-55ca7fe319b9.png)
+
+The steps to reproduce this are as follows:
+
+ - first commit - adding the baseline file contents
+ - second commit - apply changes to illustrate the issue

--- a/0002-multiple-ranges-in-one-line/example-file.yml
+++ b/0002-multiple-ranges-in-one-line/example-file.yml
@@ -18,8 +18,8 @@ matrix:
       language: c
       env:
        - TARGET_PLATFORM=win32
-       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.13.3.windows.1/MinGit-2.13.3-64-bit.zip
-       - GIT_FOR_WINDOWS_CHECKSUM=97063e2139cac40f3c8f547b85f031765062581101d69ad468188c9de0b1dca3
+       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip
+       - GIT_FOR_WINDOWS_CHECKSUM=65c12e4959b8874187b68ec37e532fe7fc526e10f6f0f29e699fa1d2449e7d92
        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.2.1/git-lfs-windows-amd64-2.2.1.zip
        - GIT_LFS_CHECKSUM=35e120c03061c7a3de8348b970da2278a2e0a865d4c67179801266a2d7674d2d
 

--- a/0002-multiple-ranges-in-one-line/example-file.yml
+++ b/0002-multiple-ranges-in-one-line/example-file.yml
@@ -1,0 +1,45 @@
+matrix:
+  include:
+    - os: linux
+      language: c
+      env:
+        - TARGET_PLATFORM=ubuntu
+        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.2.1/git-lfs-linux-amd64-2.2.1.tar.gz
+        - GIT_LFS_CHECKSUM=95bcdab9897338fd923ad3a792010d6e817114e8c3b444e1e245889b6cd68888
+
+    - os: osx
+      language: c
+      env:
+       - TARGET_PLATFORM=macOS
+       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.2.1/git-lfs-darwin-amd64-2.2.1.tar.gz
+       - GIT_LFS_CHECKSUM=1da31fa2cc75fe56486cbaf371ca4d233889a8105cc9d9435284a0a7a3c87bec
+
+    - os: linux
+      language: c
+      env:
+       - TARGET_PLATFORM=win32
+       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.13.3.windows.1/MinGit-2.13.3-64-bit.zip
+       - GIT_FOR_WINDOWS_CHECKSUM=97063e2139cac40f3c8f547b85f031765062581101d69ad468188c9de0b1dca3
+       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.2.1/git-lfs-windows-amd64-2.2.1.zip
+       - GIT_LFS_CHECKSUM=35e120c03061c7a3de8348b970da2278a2e0a865d4c67179801266a2d7674d2d
+
+compiler:
+  - gcc
+
+script:
+  - script/build.sh
+  - script/package.sh
+
+branches:
+  only:
+  - master
+  - /^v[0-9]*.[0-9]*.[0.9]*.*$/
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  file_glob: true
+  file: ${TRAVIS_BUILD_DIR}/dugite-native-v*.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
This is the first attempt to capture a regression test for our text diffs in Desktop, using this issue as a reference: https://github.com/desktop/desktop/issues/2485

 - [x] capture problem commit in isolation https://github.com/desktop/diff-tests/commit/2c2230362afd3e73ef44569e17251edd74c8f2bc
 - [ ] identify what changes need to be fixed in Desktop
 - [ ] submit a PR to Desktop to address this
 - [ ] update regression test to confirm it's been fixed